### PR TITLE
used apt value in proptype instead of string

### DIFF
--- a/utils/contexts/AlertContext.tsx
+++ b/utils/contexts/AlertContext.tsx
@@ -14,7 +14,7 @@ interface IAlert {
   id: string;
   message: string;
   autoClose: boolean;
-  type: string;
+  type: "warning"|"error"|"success";
 }
 
 const AlertContextProvider: React.FC<AlertContextProviderProps> = ({


### PR DESCRIPTION

fixed #67 
## Description
Used apt type
` type: "warning"|"error"|"success";`
instead of
` type: string;`
in proptypes of alert component
